### PR TITLE
Refactor: Apply new dark theme to website styles

### DIFF
--- a/blog-editor.css
+++ b/blog-editor.css
@@ -1,17 +1,6 @@
 /* 博客编辑器样式 */
 
-:root {
-    --primary-color: #87ceeb;
-    --dark-bg: #1a1a1a;
-    --content-bg: #282828;
-    --input-bg: #333333;
-    --border-color: #444444;
-    --text-color: #e0e0e0;
-    --text-light: #b0b0b0;
-    --text-dark: #282828;
-    --red: #e74c3c;
-    --green: #2ecc71;
-}
+/* The :root block has been removed as these variables are now global in styles.css */
 
 body {
     margin: 0;
@@ -21,7 +10,7 @@ body {
     font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
     line-height: 1.6;
     /* Added from main styles.css */
-    background-image: linear-gradient(45deg, #1a1a1a 25%, #222222 25%, #222222 50%, #1a1a1a 50%, #1a1a1a 75%, #222222 75%, #222222 100%);
+    background-image: linear-gradient(45deg, var(--dark-bg) 25%, #222222 25%, #222222 50%, var(--dark-bg) 50%, var(--dark-bg) 75%, #222222 75%, #222222 100%); /* Use var(--dark-bg) */
     background-size: 40px 40px;
     background-attachment: fixed;
     display: block; /* 覆盖styles.css中的flex布局 */
@@ -30,7 +19,7 @@ body {
 }
 
 p {
-    color: #b0b0b0; /* 稍暗的文字颜色 */
+    color: var(--text-light); /* Was #b0b0b0 */
     margin-bottom: 25px;
     font-size: 1.1em;
 }
@@ -62,7 +51,7 @@ p {
 }
 
 h1 {
-    color: #ffffff;
+    color: var(--text-color); /* Was #ffffff */
     text-align: center;
     margin-bottom: 30px;
     font-size: 2.2em;
@@ -70,7 +59,7 @@ h1 {
 }
 
 h2 {
-    color: #ffffff;
+    color: var(--text-color); /* Was #ffffff */
     margin: 25px 0 15px;
     font-size: 1.7em;
     border-bottom: 2px solid var(--primary-color);
@@ -104,7 +93,7 @@ input, textarea, select {
 input:focus, textarea:focus, select:focus {
     outline: none;
     border-color: var(--primary-color);
-    box-shadow: 0 0 0 2px rgba(135, 206, 235, 0.2);
+    box-shadow: 0 0 0 2px rgba(var(--accent-color-rgb), 0.2); /* Use accent-color-rgb for consistency */
 }
 
 .password-container {
@@ -250,8 +239,8 @@ button:active {
     position: absolute;
     top: 10px;
     right: 10px;
-    background-color: rgba(0,0,0,0.5);
-    color: white;
+    background-color: rgba(0,0,0,0.5); /* Keep as is, no direct var */
+    color: var(--text-color); /* Was white */
     border: none;
     border-radius: 4px;
     padding: 6px 10px;
@@ -291,7 +280,7 @@ button:active {
 }
 
 .markdown-content pre {
-    background-color: #222222;
+    background-color: var(--dark-bg); /* Was #222222, align with global pre style */
     padding: 15px;
     border-radius: 5px;
     overflow-x: auto;

--- a/post-enhancements.css
+++ b/post-enhancements.css
@@ -10,7 +10,7 @@
     margin: 0;
     border-radius: 6px;
     padding-top: 2rem !important;
-    background: var(--background-light);
+    background: var(--content-bg); /* Was --background-light */
     border: 1px solid var(--border-color);
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
     overflow: auto;
@@ -22,8 +22,8 @@
     left: 0;
     padding: 2px 10px;
     font-size: 0.75rem;
-    color: #d4d4d4;
-    background: #333333;
+    color: var(--text-color); /* Was #d4d4d4 */
+    background: var(--input-bg); /* Was #333333 */
     border-radius: 6px 0 6px 0;
     border: 1px solid var(--border-color);
     border-bottom: none;
@@ -37,8 +37,8 @@
     right: 0;
     padding: 0.25rem 0.5rem;
     font-size: 0.75rem;
-    background: #333333;
-    color: var(--text-muted);
+    background: var(--input-bg); /* Was #333333 */
+    color: var(--text-light); /* Was --text-muted */
     border: 1px solid var(--border-color);
     border-radius: 0 6px 0 6px;
     cursor: pointer;
@@ -48,13 +48,13 @@
 
 .copy-code-button:hover {
     opacity: 1;
-    background: #4a4a4a;
+    background: var(--border-color); /* Was #4a4a4a */
     color: var(--accent-color);
 }
 
 .copy-code-button.copied {
-    background-color: #2e7d32;
-    color: white;
+    background-color: #2e7d32; /* Specific green, keep as is */
+    color: var(--text-color); /* Was white */
 }
 
 /* 文章大纲样式 */
@@ -64,7 +64,7 @@
     right: 20px;
     width: 280px;
     max-height: calc(100vh - var(--header-height) - 40px);
-    background-color: rgba(35, 35, 35, 0.9);
+    background-color: rgba(40, 40, 40, 0.9); /* Was rgba(35,35,35,0.9), using var(--content-bg) like value */
     backdrop-filter: blur(10px);
     border-radius: 8px;
     border: 1px solid var(--border-color);
@@ -212,7 +212,7 @@
         background-color: transparent;
     }
     20% {
-        background-color: rgba(135, 206, 235, 0.2);
+        background-color: rgba(var(--accent-color-rgb), 0.2); /* Was rgba(135,206,235,0.2) */
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,14 +1,25 @@
 /* 全局样式 */
 :root {
-    --primary-color: #87ceeb;
-    --background-dark: #1a1a1a;
-    --background-light: #282828;
-    --text-color: #e0e0e0;
-    --text-muted: #b0b0b0;
-    --border-color: #444444;
-    --accent-color: #87ceeb;
-    --accent-color-rgb: 135, 206, 235;
-    --header-height: 60px;
+    --primary-color: #87ceeb; /* Existing, kept */
+    --dark-bg: #1a1a1a; /* New */
+    --content-bg: #282828; /* New */
+    --input-bg: #333333; /* New */
+    --border-color: #444444; /* Existing, same value */
+    --text-color: #e0e0e0; /* Existing, same value */
+    --text-light: #b0b0b0; /* New */
+    --text-dark: #282828; /* New */
+    --red: #e74c3c; /* New */
+    --green: #2ecc71; /* New */
+    
+    /* Old variables, aliased or replaced if possible. For now, keep accent if used by navbar */
+    --accent-color: #87ceeb; /* Existing, used by navbar, kept */
+    --accent-color-rgb: 135, 206, 235; /* Existing, used by navbar, kept */
+    --header-height: 60px; /* Existing, used by navbar, kept */
+    
+    /* Renaming old variables to new ones if values are similar or identical */
+    --background-dark: var(--dark-bg); /* Alias */
+    --background-light: var(--content-bg); /* Alias */
+    --text-muted: var(--text-light); /* Alias */
 }
 
 * {
@@ -17,17 +28,21 @@
     padding: 0;
 }
 
+/* 基本样式，设置暗色背景和浅色文字 */
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-    line-height: 1.7;
+    margin: 0;
+    padding: 0;
+    background-color: var(--dark-bg);
     color: var(--text-color);
-    background-color: var(--background-dark);
+    font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.6;
+    background-image: linear-gradient(45deg, #1a1a1a 25%, #222222 25%, #222222 50%, #1a1a1a 50%, #1a1a1a 75%, #222222 75%, #222222 100%);
     background-size: 40px 40px;
     background-attachment: fixed;
 }
 
 a {
-    color: var(--accent-color);
+    color: var(--primary-color); /* Updated to use new variable name, same color */
     text-decoration: none;
     transition: color 0.3s;
 }
@@ -36,7 +51,7 @@ a:hover {
     color: #ffffff;
 }
 
-/* 导航栏 */
+/* 导航栏 - STYLES MUST BE PRESERVED */
 .navbar {
     background-color: rgba(22, 22, 22, 0.88);
     backdrop-filter: blur(5px);
@@ -69,7 +84,7 @@ a:hover {
 }
 
 .navbar-links a {
-    color: var(--text-muted);
+    color: var(--text-light); /* Navbar uses text-muted which is aliased to text-light */
     font-weight: 500;
     position: relative;
     padding: 5px 0;
@@ -102,20 +117,29 @@ a:hover {
 }
 
 /* 容器样式 */
+/* New .container styles replacing old ones */
 .container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 20px;
+    text-align: center;
+    padding: 40px;
+    background-color: var(--content-bg); /*略浅的背景，与body区分 */
+    border-radius: 12px; /* 圆角 */
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.4); /* 增强阴影效果 */
+    max-width: 800px; /* 增加最大宽度 */
+    width: 90%; /* 响应式宽度 */
+    margin-left: auto; /* 左侧自动边距 */
+    margin-right: auto; /* 右侧自动边距 */
+    margin-top: 30px; /* 顶部边距 */
+    margin-bottom: 30px; /* 底部边距 */
 }
 
 .content-wrapper {
-    margin-top: calc(var(--header-height) + 40px);
+    margin-top: calc(var(--header-height) + 40px); /* Keep this as it's related to fixed navbar */
     margin-bottom: 50px;
 }
 
 /* 博客卡片样式 */
 .blog-card {
-    background-color: var(--background-light);
+    background-color: var(--content-bg); /* Updated to use new variable */
     border-radius: 8px;
     overflow: hidden;
     margin-bottom: 30px;
@@ -138,7 +162,7 @@ a:hover {
 }
 
 .blog-card-meta {
-    color: var(--text-muted);
+    color: var(--text-light); /* Updated to use new variable */
     font-size: 0.85em;
     margin-bottom: 15px;
     display: flex;
@@ -148,7 +172,7 @@ a:hover {
 }
 
 .blog-card-excerpt {
-    color: var(--text-muted);
+    color: var(--text-light); /* Updated to use new variable */
     margin-bottom: 20px;
 }
 
@@ -164,16 +188,16 @@ a:hover {
     padding: 4px 8px;
     margin-right: 6px;
     margin-bottom: 6px;
-    background-color: rgba(135, 206, 235, 0.1);
+    background-color: rgba(var(--accent-color-rgb), 0.1); /* Keep using accent-color-rgb for tags for now */
     border-radius: 30px;
     font-size: 0.75em;
-    color: var(--accent-color);
+    color: var(--accent-color); /* Keep using accent-color for tags for now */
     transition: background-color 0.3s;
 }
 
 .tag:hover {
     background-color: rgba(var(--accent-color-rgb), 0.25);
-    color: var(--accent-color);
+    color: var(--accent-color); /* Keep using accent-color for tags for now */
 }
 
 /* 搜索栏 */
@@ -187,7 +211,7 @@ a:hover {
     padding: 12px 50px 12px 20px;
     border-radius: 30px;
     border: none;
-    background-color: rgba(40, 40, 40, 0.8);
+    background-color: var(--input-bg); /* Updated to use new variable */
     color: white;
     font-size: 1em;
     transition: all 0.3s;
@@ -195,8 +219,8 @@ a:hover {
 
 .search-input:focus {
     outline: none;
-    background-color: rgba(50, 50, 50, 0.8);
-    box-shadow: 0 0 0 2px rgba(135, 206, 235, 0.5);
+    background-color: #3a3a3a; /* Slightly lighter than input-bg for focus */
+    box-shadow: 0 0 0 2px rgba(var(--accent-color-rgb), 0.5); /* Keep using accent-color for shadow for now */
 }
 
 .search-button {
@@ -206,7 +230,7 @@ a:hover {
     transform: translateY(-50%);
     background: none;
     border: none;
-    color: var(--accent-color);
+    color: var(--accent-color); /* Keep using accent-color for button for now */
     font-size: 1.2em;
     cursor: pointer;
     transition: color 0.3s ease;
@@ -214,7 +238,7 @@ a:hover {
 
 /* 代码高亮 */
 pre {
-    background-color: #1a1a1a;
+    background-color: var(--dark-bg); /* Updated to use new variable */
     padding: 15px;
     border-radius: 5px;
     overflow-x: auto;
@@ -239,18 +263,30 @@ code {
     line-height: 1.8;
 }
 
+/* Global H1 style from new CSS */
+h1 {
+    color: var(--text-color); /* Was #ffffff */
+    text-align: center;
+    margin-bottom: 30px;
+    font-size: 2.2em;
+    text-shadow: 0 2px 3px rgba(0,0,0,0.2);
+}
+
 .blog-content h1, 
 .blog-content h2, 
 .blog-content h3 {
-    color: white;
+    color: white; /* This is fine, new global h1 also has white */
 }
 
+/* Specific h1 style for blog content, ensure it doesn't conflict badly with global h1 */
 .blog-content h1 {
-    font-size: 2em;
+    font-size: 2em; /* Slightly smaller than global h1, this is fine for specificity */
     border-bottom: 2px solid var(--border-color);
     padding-bottom: 12px;
-    margin-top: 30px; /* Keep original or adjust as needed */
-    margin-bottom: 20px;
+    margin-top: 30px; 
+    margin-bottom: 20px; /* Global H1 has 30px, this is fine */
+    text-align: left; /* Override global text-align: center for blog content h1 */
+    text-shadow: none; /* Override global text-shadow for blog content h1 */
 }
 
 .blog-content h2 {
@@ -265,8 +301,18 @@ code {
     margin-bottom: 15px;
 }
 
+/* Global P style from new CSS */
+p {
+    color: var(--text-light); /* Was #b0b0b0, already var(--text-light) which is fine */
+    margin-bottom: 25px;
+    font-size: 1.1em;
+}
+
 .blog-content p {
-    margin-bottom: 20px;
+    margin-bottom: 20px; /* Keep specific margin */
+    font-size: 1em; /* Explicitly define font-size for blog content <p> if different from global, or remove if global is fine */
+    line-height: 1.7; /* Keep specific line-height for blog content <p> */
+    color: var(--text-light); 
 }
 
 .blog-content img {
@@ -278,29 +324,30 @@ code {
 }
 
 .blog-content blockquote {
-    border-left: 3px solid var(--accent-color);
+    border-left: 3px solid var(--primary-color); /* Updated to use new variable */
     padding-left: 15px;
     margin: 20px 0;
-    color: var(--text-muted);
-    background-color: rgba(var(--accent-color-rgb, 135, 206, 235), 0.05);
+    color: var(--text-light); /* Updated to use new variable */
+    background-color: rgba(var(--accent-color-rgb), 0.05); /* Keep using accent-color-rgb for blockquote for now */
 }
 
-/* 页脚 */
+/* 页脚 - New styles replacing old ones */
 .footer {
-    text-align: center;
-    padding: 30px 0;
-    margin-top: 50px;
-    background-color: rgba(26, 26, 26, 0.7);
-    color: var(--text-muted);
+    margin-top: 30px;
+    font-size: 0.9em;
+    color: var(--text-light); /* Was #888888 */
+    padding-top: 20px;
+    border-top: 1px solid var(--border-color); /* Already var(--border-color) */
+    text-align: center; 
 }
 
 .footer a {
-    color: var(--accent-color);
+    color: var(--primary-color);
 }
 
 /* 目录导航 */
 .table-of-contents {
-    background-color: rgba(40, 40, 40, 0.6);
+    background-color: var(--input-bg); /* Updated to use new variable */
     border-radius: 10px;
     padding: 20px;
     margin-bottom: 30px;
@@ -311,6 +358,7 @@ code {
     border-bottom: 1px solid var(--border-color);
     padding-bottom: 10px;
     margin-bottom: 15px;
+    color: var(--text-color); /* Ensure TOC headings use standard text color */
 }
 
 .table-of-contents ul {
@@ -358,18 +406,199 @@ code {
         display: block;
     }
     
+    /* .blog-header h1 specific style, keep it */
     .blog-header h1 {
-        font-size: 1.8em;
+        font-size: 1.8em; 
+    }
+
+    /* New responsive styles from issue */
+    .container { /* Merged: old had no specific container changes at 768px, new one does */
+        padding: 30px 20px;
+    }
+
+    h1 { /* Merged: new global h1 style for this breakpoint */
+        font-size: 2em;
+    }
+
+    .project-links li { /* Add if .project-links are used */
+        width: 100%; /* 小屏幕下改为单列 */
     }
 }
 
 @media (max-width: 480px) {
-    .blog-title {
+    /* Existing styles at 480px */
+    .blog-title { /* This is likely a class for a specific H1 on the blog page, keep it */
         font-size: 1.5em;
     }
     
-    .blog-container {
+    .blog-container { /* This might be a specific container on blog page, keep it */
         padding: 20px;
         margin: 30px 10px;
     }
 }
+
+/* New sections from the issue */
+
+/* 个人简介部分 */
+.profile-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-bottom: 40px;
+}
+
+.avatar {
+    width: 120px;
+    height: 120px;
+    margin-bottom: 20px;
+    position: relative;
+}
+
+.avatar-placeholder {
+    width: 100%;
+    height: 100%;
+    background-color: var(--primary-color); /* Was #87ceeb, already var */
+    border-radius: 60px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 3em;
+    font-weight: bold;
+    color: var(--text-dark); /* Was #282828, already var */
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+    transition: transform 0.8s ease; 
+}
+
+.avatar:hover .avatar-placeholder {
+    transform: rotate(10deg) scale(1.05); 
+}
+
+.bio {
+    max-width: 90%;
+    line-height: 1.8; /* Matches .blog-content p */
+    color: var(--text-light); /* Added for consistency */
+}
+
+/* 技能展示部分 */
+.skills-section {
+    margin: 30px 0;
+}
+
+.skills-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 15px;
+    margin-top: 20px;
+}
+
+.skill {
+    background-color: var(--input-bg); /* Was #333333 */
+    color: var(--text-color); /* Was #e0e0e0 */
+    padding: 10px 20px;
+    border-radius: 30px;
+    font-size: 1em;
+    border: 1px solid var(--border-color); /* Was #444444 */
+    transition: all 0.3s ease;
+}
+
+.skill:hover {
+    background-color: var(--border-color); /* Was #444444 */
+    transform: translateY(-3px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+/* 项目链接样式 */
+.project-links {
+    list-style: none; /* 移除列表标记 */
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 20px;
+}
+
+.project-links li {
+    margin-bottom: 20px; /* 列表项间距 */
+    width: calc(50% - 20px); /* 两列布局，有间距 */
+}
+
+/* 链接样式 */
+.project-links a {
+    display: block; 
+    color: var(--primary-color); /* Was #87ceeb */
+    text-decoration: none; 
+    font-size: 1.2em;
+    padding: 15px 20px;
+    border: 1px solid var(--border-color); /* Was #444444 */
+    border-radius: 8px; 
+    background-color: var(--input-bg); /* Was #333333 */
+    transition: all 0.3s ease; 
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* 链接悬停效果 */
+.project-links a:hover {
+    background-color: var(--border-color); /* Was #444444 */
+    color: var(--primary-color); /* Was #87ceeb */
+    transform: translateY(-5px); /* 上移效果 */
+    box-shadow: 0 7px 15px rgba(0, 0, 0, 0.3); /* 增强阴影 */
+}
+
+/* 图标样式 */
+.icon {
+    margin-right: 10px;
+    font-style: normal;
+}
+
+/* 联系部分 */
+.contact-section {
+    margin: 40px 0 30px;
+    padding: 20px;
+    background-color: var(--input-bg); /* Was #333333 */
+    border-radius: 10px;
+}
+
+.social-links {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 15px;
+    margin-top: 20px;
+}
+
+.social-link {
+    display: inline-flex;
+    align-items: center;
+    color: var(--text-color); /* Was #e0e0e0 */
+    background-color: var(--border-color); /* Was #444444 */
+    padding: 10px 20px;
+    border-radius: 30px;
+    font-size: 1em;
+    text-decoration: none;
+    transition: all 0.3s ease;
+}
+
+.social-link:hover {
+    background-color: var(--primary-color); /* Was #87ceeb */
+    color: var(--dark-bg); /* Was #1a1a1a */
+    transform: translateY(-3px);
+}
+
+/* 更新信息 */
+.update-info {
+    margin-top: 30px;
+    font-size: 0.9em;
+    color: var(--text-light); /* Was #777777 */
+}
+
+/* Animations */
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+/* Ensure .avatar-placeholder transition and .avatar:hover .avatar-placeholder styles are present as per new CSS */
+/* The styles for .avatar-placeholder and .avatar:hover .avatar-placeholder are already correctly placed above. */

--- a/styles.css.bak
+++ b/styles.css.bak
@@ -1,0 +1,375 @@
+/* 全局样式 */
+:root {
+    --primary-color: #87ceeb;
+    --background-dark: #1a1a1a;
+    --background-light: #282828;
+    --text-color: #e0e0e0;
+    --text-muted: #b0b0b0;
+    --border-color: #444444;
+    --accent-color: #87ceeb;
+    --accent-color-rgb: 135, 206, 235;
+    --header-height: 60px;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    line-height: 1.7;
+    color: var(--text-color);
+    background-color: var(--background-dark);
+    background-size: 40px 40px;
+    background-attachment: fixed;
+}
+
+a {
+    color: var(--accent-color);
+    text-decoration: none;
+    transition: color 0.3s;
+}
+
+a:hover {
+    color: #ffffff;
+}
+
+/* 导航栏 */
+.navbar {
+    background-color: rgba(22, 22, 22, 0.88);
+    backdrop-filter: blur(5px);
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    height: var(--header-height);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 20px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+
+.navbar-brand {
+    font-size: 1.5em;
+    font-weight: 700;
+    color: white;
+}
+
+.navbar-links {
+    display: flex;
+    list-style: none;
+}
+
+.navbar-links li {
+    margin-left: 20px;
+}
+
+.navbar-links a {
+    color: var(--text-muted);
+    font-weight: 500;
+    position: relative;
+    padding: 5px 0;
+}
+
+.navbar-links a:hover {
+    color: var(--accent-color);
+}
+
+.navbar-links a::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 0;
+    height: 2px;
+    background-color: var(--accent-color);
+    transition: width 0.3s ease-in-out;
+}
+
+.navbar-links a:hover::after {
+    width: 100%;
+}
+
+.navbar-toggle {
+    display: none;
+    color: white;
+    font-size: 1.5em;
+    cursor: pointer;
+}
+
+/* 容器样式 */
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+.content-wrapper {
+    margin-top: calc(var(--header-height) + 40px);
+    margin-bottom: 50px;
+}
+
+/* 博客卡片样式 */
+.blog-card {
+    background-color: var(--background-light);
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 30px;
+    transition: transform 0.3s, box-shadow 0.3s;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+}
+
+.blog-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+}
+
+.blog-card-content {
+    padding: 20px;
+}
+
+.blog-card-title {
+    font-size: 1.4em;
+    margin-bottom: 10px;
+}
+
+.blog-card-meta {
+    color: var(--text-muted);
+    font-size: 0.85em;
+    margin-bottom: 15px;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.blog-card-excerpt {
+    color: var(--text-muted);
+    margin-bottom: 20px;
+}
+
+.blog-card-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+/* 标签样式 */
+.tag {
+    display: inline-block;
+    padding: 4px 8px;
+    margin-right: 6px;
+    margin-bottom: 6px;
+    background-color: rgba(135, 206, 235, 0.1);
+    border-radius: 30px;
+    font-size: 0.75em;
+    color: var(--accent-color);
+    transition: background-color 0.3s;
+}
+
+.tag:hover {
+    background-color: rgba(var(--accent-color-rgb), 0.25);
+    color: var(--accent-color);
+}
+
+/* 搜索栏 */
+.search-container {
+    margin-bottom: 30px;
+    position: relative;
+}
+
+.search-input {
+    width: 100%;
+    padding: 12px 50px 12px 20px;
+    border-radius: 30px;
+    border: none;
+    background-color: rgba(40, 40, 40, 0.8);
+    color: white;
+    font-size: 1em;
+    transition: all 0.3s;
+}
+
+.search-input:focus {
+    outline: none;
+    background-color: rgba(50, 50, 50, 0.8);
+    box-shadow: 0 0 0 2px rgba(135, 206, 235, 0.5);
+}
+
+.search-button {
+    position: absolute;
+    right: 15px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: var(--accent-color);
+    font-size: 1.2em;
+    cursor: pointer;
+    transition: color 0.3s ease;
+}
+
+/* 代码高亮 */
+pre {
+    background-color: #1a1a1a;
+    padding: 15px;
+    border-radius: 5px;
+    overflow-x: auto;
+    margin: 20px 0;
+}
+
+pre code {
+    font-family: 'Fira Code', 'Courier New', Courier, monospace;
+    background-color: transparent;
+    padding: 0;
+}
+
+code {
+    font-family: 'Fira Code', 'Courier New', Courier, monospace;
+    background-color: rgba(0, 0, 0, 0.2);
+    padding: 2px 5px;
+    border-radius: 3px;
+}
+
+/* 文章内容样式 */
+.blog-content {
+    line-height: 1.8;
+}
+
+.blog-content h1, 
+.blog-content h2, 
+.blog-content h3 {
+    color: white;
+}
+
+.blog-content h1 {
+    font-size: 2em;
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 12px;
+    margin-top: 30px; /* Keep original or adjust as needed */
+    margin-bottom: 20px;
+}
+
+.blog-content h2 {
+    font-size: 1.6em;
+    margin-top: 35px;
+    margin-bottom: 18px;
+}
+
+.blog-content h3 {
+    font-size: 1.4em;
+    margin-top: 30px;
+    margin-bottom: 15px;
+}
+
+.blog-content p {
+    margin-bottom: 20px;
+}
+
+.blog-content img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 20px auto;
+    border-radius: 5px;
+}
+
+.blog-content blockquote {
+    border-left: 3px solid var(--accent-color);
+    padding-left: 15px;
+    margin: 20px 0;
+    color: var(--text-muted);
+    background-color: rgba(var(--accent-color-rgb, 135, 206, 235), 0.05);
+}
+
+/* 页脚 */
+.footer {
+    text-align: center;
+    padding: 30px 0;
+    margin-top: 50px;
+    background-color: rgba(26, 26, 26, 0.7);
+    color: var(--text-muted);
+}
+
+.footer a {
+    color: var(--accent-color);
+}
+
+/* 目录导航 */
+.table-of-contents {
+    background-color: rgba(40, 40, 40, 0.6);
+    border-radius: 10px;
+    padding: 20px;
+    margin-bottom: 30px;
+}
+
+.table-of-contents h3 {
+    margin-top: 0;
+    border-bottom: 1px solid var(--border-color);
+    padding-bottom: 10px;
+    margin-bottom: 15px;
+}
+
+.table-of-contents ul {
+    list-style-type: none;
+}
+
+.table-of-contents ul li {
+    margin-bottom: 10px;
+}
+
+/* 评论区 */
+.comments-section {
+    margin-top: 50px;
+    padding-top: 30px;
+    border-top: 1px solid var(--border-color);
+}
+
+.comments-section h3 {
+    margin-bottom: 20px;
+}
+
+/* 响应式设计 */
+@media (max-width: 768px) {
+    .navbar-links {
+        display: none;
+        position: absolute;
+        top: var(--header-height);
+        left: 0;
+        width: 100%;
+        flex-direction: column;
+        background-color: rgba(26, 26, 26, 0.95);
+        padding: 20px 0;
+        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+    }
+
+    .navbar-links.active {
+        display: flex;
+    }
+
+    .navbar-links li {
+        margin: 10px 20px;
+    }
+
+    .navbar-toggle {
+        display: block;
+    }
+    
+    .blog-header h1 {
+        font-size: 1.8em;
+    }
+}
+
+@media (max-width: 480px) {
+    .blog-title {
+        font-size: 1.5em;
+    }
+    
+    .blog-container {
+        padding: 20px;
+        margin: 30px 10px;
+    }
+}


### PR DESCRIPTION
This commit introduces a new dark theme based on the styles you provided.

Key changes:
- Updated `styles.css` with new CSS variables, body styles, container styles, and footer styles.
- Ensured existing navigation bar styles were preserved.
- Added new styles for various page elements (though some like profile/skills sections might be unused currently).
- Updated `blog-editor.css` and `post-enhancements.css` to use the new global CSS variables for a consistent look and feel.
- I created a backup of the original `styles.css` as `styles.css.bak` before modifications.